### PR TITLE
Adjust channel form

### DIFF
--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -1,90 +1,88 @@
-<form class="form-horizontal">
-<%= form_for(channel) do |f| %>
-  <% if channel.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(channel.errors.count, "error") %> prohibited this channel from being saved:</h2>
+<%= form_for(channel, html: {class: "form-horizontal"}) do |f| %>
+<% if channel.errors.any? %>
+<div id="error_explanation">
+  <h2><%= pluralize(channel.errors.count, "error") %> prohibited this channel from being saved:</h2>
 
-      <ul>
-      <% channel.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-    <div class="form-group">
-      <%= f.label :name, class: "control-label col-sm-2" %>
-      <div class="col-sm-8">
-        <%= f.text_field :name, class: 'form-control',placeholder: "Enter Channel name" %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :description, class: "control-label col-sm-2" %>
-      <div class="col-sm-8">
-        <%= f.text_area :description, class: "form-control", placeholder: "Enter description" %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <label class="control-label col-sm-2">Fields</label>
-      <div class="form-inline">
-        <%= f.check_box :field1_enable , class: 'move-left'%>
-        <%= f.text_field :field1_name, class: "form-control", placeholder: :field1_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field2_enable , class: 'move-left'%>
-        <%= f.text_field :field2_name, class: 'form-control', placeholder: :field2_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field3_enable , class: 'move-left'%>
-        <%= f.text_field :field3_name, class: 'form-control', placeholder: :field3_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field4_enable , class: 'move-left'%>
-        <%= f.text_field :field4_name, class: 'form-control', placeholder: :field4_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field5_enable , class: 'move-left'%>
-        <%= f.text_field :field5_name, class: 'form-control', placeholder: :field5_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field6_enable , class: 'move-left'%>
-        <%= f.text_field :field6_name, class: 'form-control', placeholder: :field6_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field7_enable , class: 'move-left'%>
-        <%= f.text_field :field7_name, class: 'form-control', placeholder: :field7_name %>
-      </div>
-
-      <label class="col-sm-2"></label>
-      <div class="form-inline">
-        <%= f.check_box :field8_enable , class: 'move-left'%>
-        <%= f.text_field :field8_name, class: 'form-control', placeholder: :field8_name %>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :api_key, class: "control-label col-sm-2" %>
-      <div class="col-sm-8">
-        <%= f.text_field :api_key, class: "form-control", placeholder: "Enter API key" %>
-      </div>
-    </div>
-
-    <%= f.hidden_field :user_id %>
-
-    <%= f.submit "Create channel", class: "btn btn-custom" %>
+  <ul>
+    <% channel.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>
 <% end %>
-</form>
+
+<div class="form-group">
+  <%= f.label :name, class: "control-label col-sm-2" %>
+  <div class="col-sm-8">
+    <%= f.text_field :name, class: 'form-control',placeholder: "Enter Channel name" %>
+  </div>
+</div>
+
+<div class="form-group">
+  <%= f.label :description, class: "control-label col-sm-2" %>
+  <div class="col-sm-8">
+    <%= f.text_area :description, class: "form-control", placeholder: "Enter description" %>
+  </div>
+</div>
+
+<div class="form-group">
+  <label class="control-label col-sm-2">Fields</label>
+  <div class="form-inline">
+    <%= f.check_box :field1_enable , class: 'move-left'%>
+    <%= f.text_field :field1_name, class: "form-control", placeholder: :field1_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field2_enable , class: 'move-left'%>
+    <%= f.text_field :field2_name, class: 'form-control', placeholder: :field2_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field3_enable , class: 'move-left'%>
+    <%= f.text_field :field3_name, class: 'form-control', placeholder: :field3_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field4_enable , class: 'move-left'%>
+    <%= f.text_field :field4_name, class: 'form-control', placeholder: :field4_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field5_enable , class: 'move-left'%>
+    <%= f.text_field :field5_name, class: 'form-control', placeholder: :field5_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field6_enable , class: 'move-left'%>
+    <%= f.text_field :field6_name, class: 'form-control', placeholder: :field6_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field7_enable , class: 'move-left'%>
+    <%= f.text_field :field7_name, class: 'form-control', placeholder: :field7_name %>
+  </div>
+
+  <label class="col-sm-2"></label>
+  <div class="form-inline">
+    <%= f.check_box :field8_enable , class: 'move-left'%>
+    <%= f.text_field :field8_name, class: 'form-control', placeholder: :field8_name %>
+  </div>
+</div>
+
+<div class="form-group">
+  <%= f.label :api_key, class: "control-label col-sm-2" %>
+  <div class="col-sm-8">
+    <%= f.text_field :api_key, class: "form-control", placeholder: "Enter API key" %>
+  </div>
+</div>
+
+<%= f.hidden_field :user_id %>
+
+<%= f.submit "Create channel", class: "btn btn-custom" %>
+<% end %>


### PR DESCRIPTION
I found bug regarding channel form.

Current code in views/channels/_form.html.erb is following.
```
<form class="form-horizontal">
 <%= form_for(channel) do |f| %>
...
 <% end %>
</form>
```
This render to following html.
```
<form class="form-horizontal">
<form class="new_channel" id="new_channel" action="/channels" accept-charset="UTF-8" method="post">
...
</form>
</form>
```
Form tag can't be available to nest.
In this case, you can't create new channel, even if push create button.
Because second form tag don't work.

Hence, I improve like this.
```
<%= form_for(channel, html: {class: 'form-horizontal'}) do |f| %>
...
<% end %>
```
This render to following html.
```
<form class="form-horizontal" id="new_channel" action="/channels" accept-charset="UTF-8" method="post">
...
</form>
```
It seems to work good!