### PR TITLE
Erase sensor_values table in channel show page

### DIFF
--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -61,25 +61,4 @@
     </div>
 <% end %>
 
-<table class="table table-striped table-bordered">
-  <thead>
-    <tr>
-      <th>Date</th>
-      <% @channel.enabled_fields.each do |field| %>
-        <th><%= field.name %></th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <% @channel.sensor_values.each do |val| %>
-      <tr>
-        <td><%= val.timestamp %></td>
-        <% @channel.enabled_fields.each do |field| %>
-          <td><%= val["value#{field.index}"] %></td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-
 <%= link_to 'New Sensor value', new_sensor_value_path(channel_id: @channel) %>


### PR DESCRIPTION
I erased large table for sensor_values in channel show page.